### PR TITLE
Delete pids command line check for stale locks

### DIFF
--- a/lib/pidlock.js
+++ b/lib/pidlock.js
@@ -163,9 +163,8 @@ module.exports.guard = function(dir, key, callback) {
                 }
 
                 // The moment of truth.
-                // If the lock is not stale and the "other" command line is the same as "mine",
-                // then this instance of the app should not start.
-                if (!lock_is_stale && data.me_cmd === data.other_cmd) {
+                // If the lock is not stale then this instance of the app should not start.
+                if (!lock_is_stale) {
                     data.state = 'CONFIRMED_TO_NOT_START';
                     return {
                         error: {},


### PR DESCRIPTION
The "other" command line could not be the same as "mine" because it make no sense. Lock could be created by an another nodejs program. In my case that was the same script but started through child_process.exec which altered its command line string.